### PR TITLE
Zones to lowercase

### DIFF
--- a/adblock/gen_adblock.sh
+++ b/adblock/gen_adblock.sh
@@ -80,7 +80,7 @@ download_file () {
       if [ "${url##*.}" == "zone" ];then
         curl --progress-bar $url | sed -rn 's/^local-zone: "(.*)".*$/\1/p' | sort >> $list
       else
-        curl --progress-bar $url | grep -o '^[^#]*' | grep -v "::1" | grep -v "0.0.0.0 0.0.0.0" | sed '/^$/d' | sed 's/\ /\\ /g' | awk '{print $NF}' | grep -o '^[^\\]*' | grep -o '^[^\\$]*' | sort >> $list
+        curl --progress-bar $url | grep -o '^[^#]*' | grep -v "::1" | grep -v "0.0.0.0 0.0.0.0" | sed '/^$/d' | sed 's/\ /\\ /g' | awk '{print tolower($NF)}' | grep -o '^[^\\]*' | grep -o '^[^\\$]*' | sort >> $list
       fi
       dos2unix $list
       count=$((count + 1))


### PR DESCRIPTION
Convert texts to lower case to avoid warnings when a zone is duplicated because there are lowercase and uppercase versions, found in some adblock lists.