### PR TITLE
Workaround for Entware Binaries using RUNPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Unbound-Asuswrt-Merlin
 
-## v1.4.6
-### Updated on 2026-Mar-28
+## v1.4.7
+### Updated on 2026-Apr-11
 
 ## About
 This repo includes support files used by Unbound_Manager.sh maintained by MartineauUK.

--- a/unbound_stats.sh
+++ b/unbound_stats.sh
@@ -37,7 +37,7 @@
 ##           June 14 2025 - Added "help" parameter to show list of available commands [Martinski W.]
 ##            Aug 11 2025 - Added error checking and handling plus various code improvements.
 #########################################################################################################
-# Last Modified: 2026-Mar-28
+# Last Modified: 2026-Apr-11
 #-------------------------------------------------
 
 ############## Shellcheck Directives ##############
@@ -52,8 +52,8 @@
 # shellcheck disable=SC3045
 ###################################################
 
-readonly SCRIPT_VERSION="v1.4.6"
-readonly SCRIPT_VERSTAG="26032808"
+readonly SCRIPT_VERSION="v1.4.7"
+readonly SCRIPT_VERSTAG="26041104"
 SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/juched78/Unbound-Asuswrt-Merlin/$SCRIPT_BRANCH"
 
@@ -105,6 +105,9 @@ readonly INFO="${BOLD}\e[36m"
 readonly REDct="\e[1;31m"
 readonly GRNct="\e[1;32m"
 readonly MGNTct="\e[1;35m"
+
+# Workaround for Entware ELF binaries compiled with RUNPATH #
+unset LD_LIBRARY_PATH
 
 # Give priority to built-in binaries #
 export PATH="/bin:/usr/bin:/sbin:/usr/sbin:$PATH"


### PR DESCRIPTION
Added "`unset LD_LIBRARY_PATH`" line as a workaround due to the latest Entware binaries using the **RUNPATH** embedded library search path mechanism instead of the previous **RPATH** method. **RUNPATH** is searched **AFTER** the LD_LIBRARY_PATH definitions, whereas **RPATH** has higher priority than the LD_LIBRARY_PATH environment variable, so it's searched **FIRST**.
