### PR TITLE
Fix Webpage / Add Support for BE19000AI

### DIFF
--- a/unbound_stats.sh
+++ b/unbound_stats.sh
@@ -55,7 +55,7 @@
 readonly SCRIPT_VERSION="v1.4.8"
 readonly SCRIPT_VERSTAG="26041500"
 SCRIPT_BRANCH="develop"
-SCRIPT_REPO="https://raw.githubusercontent.com/juched78/Unbound-Asuswrt-Merlin/$SCRIPT_BRANCH"
+SCRIPT_REPO="https://raw.githubusercontent.com/ExtremeFiretop/Unbound-Asuswrt-Merlin/$SCRIPT_BRANCH"
 
 #define www script names#
 readonly SCRIPT_WEBPAGE_DIR="$(readlink -f /www/user)"
@@ -1758,13 +1758,13 @@ case "$1" in
 	;;
 	develop)
 		SCRIPT_BRANCH="develop"
-		SCRIPT_REPO="https://raw.githubusercontent.com/juched78/Unbound-Asuswrt-Merlin/$SCRIPT_BRANCH"
+		SCRIPT_REPO="https://raw.githubusercontent.com/ExtremeFiretop/Unbound-Asuswrt-Merlin/$SCRIPT_BRANCH"
 		Update_Version force
 		exit 0
 	;;
 	stable)
 		SCRIPT_BRANCH="master"
-		SCRIPT_REPO="https://raw.githubusercontent.com/juched78/Unbound-Asuswrt-Merlin/$SCRIPT_BRANCH"
+		SCRIPT_REPO="https://raw.githubusercontent.com/ExtremeFiretop/Unbound-Asuswrt-Merlin/$SCRIPT_BRANCH"
 		Update_Version force
 		exit 0
 	;;

--- a/unbound_stats.sh
+++ b/unbound_stats.sh
@@ -55,7 +55,7 @@
 readonly SCRIPT_VERSION="v1.4.8"
 readonly SCRIPT_VERSTAG="26041500"
 SCRIPT_BRANCH="develop"
-SCRIPT_REPO="https://raw.githubusercontent.com/ExtremeFiretop/Unbound-Asuswrt-Merlin/$SCRIPT_BRANCH"
+SCRIPT_REPO="https://raw.githubusercontent.com/juched78/Unbound-Asuswrt-Merlin/$SCRIPT_BRANCH"
 
 #define www script names#
 readonly SCRIPT_WEBPAGE_DIR="$(readlink -f /www/user)"
@@ -1758,13 +1758,13 @@ case "$1" in
 	;;
 	develop)
 		SCRIPT_BRANCH="develop"
-		SCRIPT_REPO="https://raw.githubusercontent.com/ExtremeFiretop/Unbound-Asuswrt-Merlin/$SCRIPT_BRANCH"
+		SCRIPT_REPO="https://raw.githubusercontent.com/juched78/Unbound-Asuswrt-Merlin/$SCRIPT_BRANCH"
 		Update_Version force
 		exit 0
 	;;
 	stable)
 		SCRIPT_BRANCH="master"
-		SCRIPT_REPO="https://raw.githubusercontent.com/ExtremeFiretop/Unbound-Asuswrt-Merlin/$SCRIPT_BRANCH"
+		SCRIPT_REPO="https://raw.githubusercontent.com/juched78/Unbound-Asuswrt-Merlin/$SCRIPT_BRANCH"
 		Update_Version force
 		exit 0
 	;;

--- a/unboundstats_www.asp
+++ b/unboundstats_www.asp
@@ -232,6 +232,34 @@ function dateDiff(d1, d2) {
 
 var BarChartHistogram, BarChartAnswers, BarChartTopBlocked, BarChartTopReplies;
 var charttypehistogram, charttypeanswers, charttypetopblocked, charttypetopreplies;
+
+/*
+ * Compatibility layer for newer ASUS BE19000AI where the old
+ * global "cookie" helper was removed in favour of localStorage.
+ * Info here: https://www.snbforums.com/threads/graphical-statistics-gui-add-on-tab-script-doesnt-work-on-be19000ai.97455/post-995793
+ */
+if (
+    typeof window.cookie === "undefined" ||
+    typeof window.cookie.get !== "function" ||
+    typeof window.cookie.set !== "function"
+) {
+    window.cookie = {
+        get: function (key) {
+            return window.localStorage.getItem(key);
+        },
+
+        set: function (key, value) {
+            window.localStorage.setItem(key, String(value));
+        },
+
+        unset: function (key) {
+            window.localStorage.removeItem(key);
+        }
+    };
+
+    console.log("Installed localStorage compatibility for cookie API.");
+}
+
 var ShowLines=GetCookie("ShowLines");
 var ShowFill=GetCookie("ShowFill");
 Chart.defaults.global.defaultFontColor = "#CCC";


### PR DESCRIPTION
Fix Webpage / Add Support for BE19000AI

More info found here: https://www.snbforums.com/threads/graphical-statistics-gui-add-on-tab-script-doesnt-work-on-be19000ai.97455/post-995793

In short, a user with a newer BE19000AI router cannot get this working.
Seems a new compatibility layer will be needed to support both new and older devices.